### PR TITLE
Add option to only generate transactions before today.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,13 @@ $ bean-report example.beancount print
 ```
 
 Note that the original template, on 2022-01-01, is not present in this output. This is always true: if a template's schedule would not generate its original date when evaluated, the template Transaction will not be produced.
+
+### Options
+
+Additionally, the following options are available which modify the entries of the plugin:
+1. `only_past_transactions`
+
+Default: Not set
+
+Only generates transactions before today's date.
+

--- a/plugin.py
+++ b/plugin.py
@@ -8,7 +8,7 @@ __plugins__ = [ 'repete', ]
 
 REPETE = 'repete'
 
-def repete(entries, options):
+def repete(entries, options, settings=None):
     new_entries = []
     rubbish_bin = []
     for txn in data.filter_txns(entries):
@@ -20,7 +20,11 @@ def repete(entries, options):
                 new = copy.deepcopy(txn)
                 new = new._replace(date=i.date())
                 del new.meta[REPETE]
-                new_entries.append(new)
+                if settings == "only_past_transactions":
+                    if new.date <= datetime.date.today():
+                        new_entries.append(new)
+                else:
+                    new_entries.append(new)
 
     for txn in rubbish_bin:
         entries.remove(txn)


### PR DESCRIPTION
This commit adds the option `only_past_transactions` which if set only generates transactions before today. As an example, if today is 2023-10-16, the transactions after 2023-10-16 will not be generated.